### PR TITLE
Fix mistaken "ethereal"

### DIFF
--- a/views/dev/slash_command.erb
+++ b/views/dev/slash_command.erb
@@ -125,7 +125,7 @@
         if (event.target.responseText != '') {
           show({
             headerColor: '#F012BE',
-            headerText: '[sync][ethereal]',
+            headerText: '[sync][ephemeral]',
             bodyText: event.target.responseText,
           });
         }


### PR DESCRIPTION
Was supposed to be "ephemeral".