### PR TITLE
Upgrade GH Actions postgres → 12.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     container: ruby:3.0.0
     services:
       postgres:
-        image: postgres:12.2
+        image: postgres:12.4
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
It's what's on production, so might as well match, even though it's just
minor versions.